### PR TITLE
squid:S1905 - Redundant casts should not be used

### DIFF
--- a/src/main/java/eu/socialsensor/benchmarks/ClusteringBenchmark.java
+++ b/src/main/java/eu/socialsensor/benchmarks/ClusteringBenchmark.java
@@ -43,7 +43,7 @@ public class ClusteringBenchmark extends BenchmarkBase implements RequiresGraphD
         this.cacheValues = new ArrayList<Integer>();
         if (config.getCacheValues() == null)
         {
-            int cacheValueMultiplier = (int) config.getCacheIncrementFactor().intValue() * config.getNodesCount();
+            int cacheValueMultiplier = config.getCacheIncrementFactor().intValue() * config.getNodesCount();
             for (int i = 1; i <= config.getCacheValuesCount(); i++)
             {
                 cacheValues.add(i * cacheValueMultiplier);

--- a/src/main/java/eu/socialsensor/graphdatabases/OrientGraphDatabase.java
+++ b/src/main/java/eu/socialsensor/graphdatabases/OrientGraphDatabase.java
@@ -126,7 +126,7 @@ public class OrientGraphDatabase extends GraphDatabaseBase<Iterator<Vertex>, Ite
     {
         final OrientVertex v2 = (OrientVertex) getVertex(i);
 
-        List<ORID> result = (List<ORID>) new OSQLFunctionShortestPath().execute(graph,
+        List<ORID> result = new OSQLFunctionShortestPath().execute(graph,
             null, null, new Object[] { ((OrientVertex) v1).getRecord(), v2.getRecord(), Direction.OUT, 5 },
             new OBasicCommandContext());
 
@@ -405,7 +405,7 @@ public class OrientGraphDatabase extends GraphDatabaseBase<Iterator<Vertex>, Ite
         OrientGraph g;
         OrientGraphFactory graphFactory = new OrientGraphFactory("plocal:" + dbPath.getAbsolutePath());
         g = graphFactory.getTx();
-        ((OrientGraph) g).setUseLightweightEdges(this.useLightWeightEdges);
+        g.setUseLightweightEdges(this.useLightWeightEdges);
         return g;
     }
 

--- a/src/main/java/eu/socialsensor/insert/OrientSingleInsertion.java
+++ b/src/main/java/eu/socialsensor/insert/OrientSingleInsertion.java
@@ -37,8 +37,8 @@ public final class OrientSingleInsertion extends InsertionBase<Vertex>
         // TODO why commit twice? is this a nested transaction?
         if (orientGraph instanceof TransactionalGraph)
         {
-            ((TransactionalGraph) orientGraph).commit();
-            ((TransactionalGraph) orientGraph).commit();
+            orientGraph.commit();
+            orientGraph.commit();
         }
     }
 
@@ -58,7 +58,7 @@ public final class OrientSingleInsertion extends InsertionBase<Vertex>
 
         if (orientGraph instanceof TransactionalGraph)
         {
-            ((TransactionalGraph) orientGraph).commit();
+            orientGraph.commit();
         }
 
         return v;
@@ -70,7 +70,7 @@ public final class OrientSingleInsertion extends InsertionBase<Vertex>
         super.post();
         if (orientGraph instanceof TransactionalGraph)
         {
-            ((TransactionalGraph) orientGraph).commit();
+            orientGraph.commit();
         }
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1905 - Redundant casts should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1905
Please let me know if you have any questions.
George Kankava